### PR TITLE
add missing assoc-in

### DIFF
--- a/src/konserve_carmine/core.clj
+++ b/src/konserve_carmine/core.clj
@@ -78,6 +78,8 @@
           (finally
             (close! res-ch))))))
 
+  (-assoc-in [this key-vec val] (-update-in this key-vec (fn [_] val)))
+
   (-dissoc [this key]
     (let [id (str (uuid key))
           res-ch (chan)]


### PR DESCRIPTION
Hi,

I'm trying to use datahike with Redis, via konserve-carmine.
But it reports an error like below:

`
objc[67746]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/bin/java (0x1031124c0) and /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/jre/lib/libinstrument.dylib (0x12839b4e0). One of the two will be used. Which one is undefined.
Exception in thread "async-dispatch-6" java.lang.AbstractMethodError: Method konserve_carmine/core/CarmineStore._assoc_in(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; is abstract
	at konserve_carmine.core.CarmineStore._assoc_in(core.clj)
	at konserve.core$assoc_in$fn__23130$state_machine__16276__auto____23137$fn__23140.invoke(core.cljc:89)
	at konserve.core$assoc_in$fn__23130$state_machine__16276__auto____23137.invoke(core.cljc:87)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:973)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:972)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:977)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:975)
	at konserve.core$assoc_in$fn__23130.invoke(core.cljc:87)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
`

So I add the missing assoc-in . Please allow to merge to konserve-carmine.
Thanks,
- Cox